### PR TITLE
chore: rename the `package` in the lakefile to Kaplansky4

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -20,7 +20,7 @@ def weakLeanArgs : Array String :=
   else
     #[]
 
-package «flt-regular» where
+package Kaplansky4 where
   leanOptions := #[
     ⟨`relaxedAutoImplicit, false⟩, -- prevents typos to be interpreted as new free variables
     ⟨`pp.unicode.fun, true⟩, -- pretty-prints `fun a ↦ b`


### PR DESCRIPTION
The current name makes for a very confusing reservoir entry! https://reservoir.lean-lang.org/@riccardobrasca/flt-regular